### PR TITLE
Send test coverages to CodeClimate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,35 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+    - name: Install cc-test-reporter
+      run: |
+        curl -Lo cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+        chmod +x cc-test-reporter
+    - run: ./cc-test-reporter before-build
+      env:
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
     - run: bundle exec rake spec
+    - name: Format coverage
+      run: |
+        # Workaround for https://github.com/codeclimate/test-reporter/issues/495
+        jq 'map_values(. | map_values(if type=="object" then map_values(.lines) else . end))' coverage/.resultset.json > coverage/workaround.resultset.json
+        ./cc-test-reporter format-coverage --input-type simplecov --output 'codeclimate-${{ matrix.ruby-version }}.json' coverage/workaround.resultset.json
+    - uses: actions/upload-artifact@v3
+      with:
+        name: coverages
+        path: codeclimate-${{ matrix.ruby-version }}.json
+  upload-coverage:
+    runs-on: ubuntu-20.04
+    needs: test
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: coverages
+    - name: Install cc-test-reporter
+      run: |
+        curl -Lo cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+        chmod +x cc-test-reporter
+    - name: Upload coverage
+      run: ./cc-test-reporter sum-coverage --output - codeclimate-*.json | ./cc-test-reporter upload-coverage --debug --input -
+      env:
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,11 @@
 ROOT = File.expand_path('..', __dir__)
 $LOAD_PATH.unshift(File.join(ROOT, 'lib'), File.join(ROOT, 'spec'))
 
+require 'simplecov'
+SimpleCov.start do
+  load_profile 'test_frameworks'
+  enable_coverage :branch
+end
 require 'danger_plugin'
 require 'support/helpers'
 


### PR DESCRIPTION
- Measure coverages with simplecov
- Send merged coverages to codeclimate.com
