### PR TITLE
Use HTML instead of Markdown in comments

### DIFF
--- a/lib/danger/danger_plugin_lint.rb
+++ b/lib/danger/danger_plugin_lint.rb
@@ -46,11 +46,11 @@ module Danger
     end
 
     def format_rule(rule)
-      <<~GFM
-        **#{rule.title}** - **#{rule.metadata[:name]}** (#{rule.type}):
+      <<~HTML
+        <strong>#{rule.title}</strong> - <strong>#{rule.metadata[:name]}</strong> (#{rule.type}):
         #{to_html(rule.description)}
         #{link(rule.ref)}
-      GFM
+      HTML
     end
 
     def link(ref)

--- a/lib/danger/danger_plugin_lint.rb
+++ b/lib/danger/danger_plugin_lint.rb
@@ -38,15 +38,19 @@ module Danger
 
     def display_rules(method, rules)
       rules.each do |rule|
-        message = <<~GFM
-          **#{rule.title}** - **#{rule.metadata[:name]}** (#{rule.type}):
-          #{to_html(rule.description)}
-          #{link(rule.ref)}
-        GFM
+        message = format_rule(rule)
         abs_file, line = rule.metadata[:files][0]
         file = Pathname.new(abs_file).relative_path_from(Dir.pwd).to_s
         public_send(method, message, file: file, line: line)
       end
+    end
+
+    def format_rule(rule)
+      <<~GFM
+        **#{rule.title}** - **#{rule.metadata[:name]}** (#{rule.type}):
+        #{to_html(rule.description)}
+        #{link(rule.ref)}
+      GFM
     end
 
     def link(ref)

--- a/lib/danger/danger_plugin_lint.rb
+++ b/lib/danger/danger_plugin_lint.rb
@@ -40,7 +40,7 @@ module Danger
       rules.each do |rule|
         message = <<~GFM
           **#{rule.title}** - **#{rule.metadata[:name]}** (#{rule.type}):
-          #{rule.description}
+          #{to_html(rule.description)}
           #{link(rule.ref)}
         GFM
         abs_file, line = rule.metadata[:files][0]
@@ -59,6 +59,13 @@ module Danger
               'https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb'
             end
       %(@see - <a href="#{url}">#{url}</a>)
+    end
+
+    def to_html(markdown)
+      # As the current Danger uses nothing but backquotes in syntax of Markdown,
+      # this method just replaces backquotes to `<code>` tag.
+      # @see https://github.com/danger/danger/blob/v9.0.0/lib/danger/plugin_support/plugin_linter.rb#L93-L128
+      markdown.gsub(/`(.*?)`/, '<code>\1</code>')
     end
   end
 end

--- a/lib/danger/danger_plugin_lint.rb
+++ b/lib/danger/danger_plugin_lint.rb
@@ -50,14 +50,15 @@ module Danger
     end
 
     def link(ref)
-      case ref
-      when Range
-        "@see - https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L#{ref.min}-L#{ref.max}"
-      when Integer
-        "@see - https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L#{ref}"
-      else
-        '@see - https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb'
-      end
+      url = case ref
+            when Range
+              "https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L#{ref.min}-L#{ref.max}"
+            when Integer
+              "https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb#L#{ref}"
+            else
+              'https://github.com/dbgrandi/danger-prose/blob/v2.0.0/lib/danger_plugin.rb'
+            end
+      %(@see - <a href="#{url}">#{url}</a>)
     end
   end
 end

--- a/spec/danger/danger_plugin_lint_spec.rb
+++ b/spec/danger/danger_plugin_lint_spec.rb
@@ -14,17 +14,17 @@ RSpec.describe Danger::DangerPluginLint do
 
       it 'reports errors' do
         expect(dangerfile.status_report[:errors]).to contain_exactly(
-          a_string_starting_with('**Description Markdown** - **TestPlugin** (class):'),
-          a_string_starting_with('**Examples** - **TestPlugin** (class):'),
-          a_string_starting_with('**Description** - **test_method** (method):')
+          a_string_starting_with('<strong>Description Markdown</strong> - <strong>TestPlugin</strong> (class):'),
+          a_string_starting_with('<strong>Examples</strong> - <strong>TestPlugin</strong> (class):'),
+          a_string_starting_with('<strong>Description</strong> - <strong>test_method</strong> (method):')
         )
       end
 
       it 'reports warnings' do
         expect(dangerfile.status_report[:warnings]).to contain_exactly(
-          a_string_starting_with('**Tags** - **TestPlugin** (class):'),
-          a_string_starting_with('**References** - **TestPlugin** (class):'),
-          a_string_starting_with('**Return Type** - **test_method** (method):')
+          a_string_starting_with('<strong>Tags</strong> - <strong>TestPlugin</strong> (class):'),
+          a_string_starting_with('<strong>References</strong> - <strong>TestPlugin</strong> (class):'),
+          a_string_starting_with('<strong>Return Type</strong> - <strong>test_method</strong> (method):')
         )
       end
     end


### PR DESCRIPTION
- Emit HTML link
- Replace backquotes to code tag
